### PR TITLE
Update default paths for mafile export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENT TASK
+
+This repository stores PowerShell scripts for managing Steam bot credentials.
+
+## Tasks
+- Parse `.mafile` files for username, password, shared_secret and identity_secret.
+- Save a combined CSV of all bots to `Exported accs/steam_credentials.csv`.
+- Write individual JSON files for each bot to `Exported accs/<username>-credentials.json`.
+
+Run `extract-mafiles.ps1` with PowerShell 5 or later to produce the output files.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # CS2SteamfarmManagement
-CS2SteamfarmManagement-for win 10 powershell
+
+This repository contains utilities for managing multiple Steam bot accounts on Windows 10.
+
+## extract-mafiles.ps1
+`extract-mafiles.ps1` scans a folder for `.mafile` files, extracts each bot's credentials, and generates easy to use output.
+
+When you run the script it will by default read files from
+`C:\Users\Felix\Desktop\AFEEEEEEKS\maFiles` and output the results to
+`C:\Users\Felix\Desktop\AFEEEEEEKS\Exported accs`.
+1. Create a folder called `Exported accs` (if it does not already exist).
+2. Parse every `.mafile` in the specified input folder to get the account `username`, `password`, `shared_secret` and `identity_secret` values.
+3. Write a CSV file named `steam_credentials.csv` in `Exported accs` containing one line per bot formatted as:
+   `username,password,shared_secret,identity_secret`.
+4. Create one JSON file per bot inside `Exported accs` named `<username>-credentials.json` with the following structure:
+
+```json
+{
+    "<username>": {
+        "password": "<password>",
+        "shared_secret": "<shared_secret>",
+        "identity_secret": "<identity_secret>"
+    }
+}
+```
+
+You can run the script in PowerShell with the default paths:
+
+```powershell
+powershell -File .\extract-mafiles.ps1
+```
+
+Or specify custom locations:
+
+```powershell
+powershell -File .\extract-mafiles.ps1 -InputFolder <path> -OutputFolder <path>
+```
+
+## Requirements
+- Windows 10 with PowerShell 5 or newer.
+- The folder containing your `.mafile` files exported from ASF or similar tools.
+
+## License
+This project is licensed under the MIT License (see `LICENSE`).

--- a/extract-mafiles.ps1
+++ b/extract-mafiles.ps1
@@ -1,0 +1,42 @@
+# Requires -Version 5
+param(
+    [string]$InputFolder = 'C:\Users\Felix\Desktop\AFEEEEEEKS\maFiles',
+    [string]$OutputFolder = 'C:\Users\Felix\Desktop\AFEEEEEEKS\Exported accs'
+)
+
+if (-not (Test-Path $OutputFolder)) {
+    New-Item -ItemType Directory -Path $OutputFolder | Out-Null
+}
+
+$csvRecords = @()
+
+Get-ChildItem -Path $InputFolder -Filter '*.mafile' | ForEach-Object {
+    $content = Get-Content $_.FullName -Raw | ConvertFrom-Json
+    $username = $content.account_name
+    $password = $content.password
+    $sharedSecret = $content.shared_secret
+    $identitySecret = $content.identity_secret
+
+    $csvRecords += [pscustomobject]@{
+        username = $username
+        password = $password
+        shared_secret = $sharedSecret
+        identity_secret = $identitySecret
+    }
+
+    $creds = @{ 
+        $username = @{ 
+            password = $password
+            shared_secret = $sharedSecret
+            identity_secret = $identitySecret
+        }
+    } | ConvertTo-Json -Depth 3
+
+    $outFile = Join-Path $OutputFolder "$username-credentials.json"
+    $creds | Set-Content $outFile
+}
+
+$csvPath = Join-Path $OutputFolder 'steam_credentials.csv'
+$csvRecords | Export-Csv -Path $csvPath -NoTypeInformation
+
+Write-Output "Credentials exported to $csvPath and individual json files in $OutputFolder"


### PR DESCRIPTION
## Summary
- update extract-mafiles.ps1 default paths to match requested directories
- explain new defaults and usage in README
- update AGENTS instructions with new output folder

## Testing
- `pwsh -File extract-mafiles.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873bb545e0883219919d9da889a1213